### PR TITLE
Add `update-backlog` subcommand with first `promote-perma-passing` preset

### DIFF
--- a/moz-webgpu-cts/src/main.rs
+++ b/moz-webgpu-cts/src/main.rs
@@ -1533,26 +1533,22 @@ fn search_for_repo_root() -> Result<PathBuf, AlreadyReportedToCommandline> {
                 dir
             })
     };
-    let gecko_source_root =
-        find_up("Mercurial", ".hg").or_else(|e| match find_up("Git", ".git") {
-            Ok(path) => {
-                log::debug!("{e:?}");
-                Ok(path)
-            }
-            Err(e2) => {
-                log::warn!("{e:?}");
-                log::warn!("{e2:?}");
-                log::error!("failed to automatically find a repository root");
-                Err(AlreadyReportedToCommandline)
-            }
-        })?;
+    let source_root = find_up("Mercurial", ".hg").or_else(|e| match find_up("Git", ".git") {
+        Ok(path) => {
+            log::debug!("{e:?}");
+            Ok(path)
+        }
+        Err(e2) => {
+            log::warn!("{e:?}");
+            log::warn!("{e2:?}");
+            log::error!("failed to automatically find a repository root");
+            Err(AlreadyReportedToCommandline)
+        }
+    })?;
 
-    log::info!(
-        "detected repository root at {}",
-        gecko_source_root.display()
-    );
+    log::info!("detected repository root at {}", source_root.display());
 
-    Ok(gecko_source_root)
+    Ok(source_root)
 }
 
 struct AlreadyReportedToCommandline;


### PR DESCRIPTION
We at Mozilla recently [added](https://bugzilla.mozilla.org/show_bug.cgi?id=1893054) the `implementation-status: backlog` property to all test cases (see [upstream docs on metadata](https://web-platform-tests.org/tools/wptrunner/docs/expectation.html)), so we can create a workflow for incrementally making WebGPU CTS [visible to Firefox's CI sheriffing team](https://wiki.mozilla.org/Sheriffing/Job_Visibility_Policy). The idea is to incrementally remove it as we determine contradictory test results are worth filing bugs for. We now [use](https://searchfox.org/mozilla-central/rev/5ff3324fe989a19c6fa5ac5b923089ef4ce2ebb2/taskcluster/kinds/test/web-platform.yml#253,258-264,307,312) `implementation-status` for both [tier 2 and tier 3 of Firefox CI](https://wiki.mozilla.org/Sheriffing/Job_Visibility_Policy#Overview_of_the_Job_Visibility_Tiers). I'm currently calling the migration of a test from a less stable tier to a more stable tier by removing `implementation-status: backlog` a "promotion".

 We do experiments in promoting tests according to heuristics like "promote permanently `PASS`ing tests" (already implemented here), "promote tests that aren't observed to `FAIL` or `CRASH`" (to be implemented in #109), with more to come. The workflow then becomes:

1. Run tests, and gather `wptreport.json` files.
2. Run `update-expected` as desired for `backlog`ged tests, and create a commit based on changes.
3. Run `update-backlog` to tentatively promote tests. Commit and submit to CI as an experiment.
4. Check tentatively promoted tests are successful in the above experiment. Where they are not, demote them, preferably with bugs in Bugzilla.

We consider using `implementation-status: backlog` to be valuable because:

* `wptrunner` has CLI support for filtering tests by implementation status, so the lift to adjust our CI was light.
* It's a clear signal that a test is not yet considered valuable to run as a blocker in CI yet.
* It's orthogonal to `expected`; sometimes, we want to model that a test should pass, but not block CI on it yet; sometimes, we want a test to be expected to `FAIL`, and block CI when it starts `PASS`ing. Concretely, the former case came up recently with [bug 1897131](https://bugzilla.mozilla.org/show_bug.cgi?id=1897131).

---


<details><summary>Original OP</summary>

I'm currently planning on separating the corpus of WebGPU CTS test runs in Firefox CI into testing based on the `implementation-status` (see [bug 1873687](https://bugzilla.mozilla.org/show_bug.cgi?id=1873687)). I'm using this PR as a way to explore automatically changing the `implementation-status`.