### PR TITLE
`process-reports`: taint subtest timeouts by suspicion

### DIFF
--- a/moz-webgpu-cts/src/main.rs
+++ b/moz-webgpu-cts/src/main.rs
@@ -604,7 +604,7 @@ fn run(cli: Cli) -> ExitCode {
                         } = entry;
 
                         let mut meta_props = meta_props.unwrap_or_default();
-                        meta_props.expectations = Some('resolve: {
+                        let reconciled = 'resolve: {
                             let reported = |platform, build_profile| {
                                 reported
                                     .get(&platform)
@@ -645,7 +645,8 @@ fn run(cli: Cli) -> ExitCode {
                             } else {
                                 all_reported()
                             }
-                        });
+                        };
+                        meta_props.expectations = Some(reconciled);
                         meta_props
                     }
 

--- a/moz-webgpu-cts/src/main.rs
+++ b/moz-webgpu-cts/src/main.rs
@@ -681,12 +681,10 @@ fn run(cli: Cli) -> ExitCode {
                             found_reconciliation_err = true;
                             log::error!("internal error: duplicate test path {test_path:?}");
                         }
-                        subtests.insert(
-                            subtest_name,
-                            Subtest {
-                                properties: reconcile(subtest, preset),
-                            },
-                        );
+
+                        let mut properties = reconcile(subtest, preset);
+
+                        subtests.insert(subtest_name, Subtest { properties });
                     }
 
                     if subtests.is_empty() && properties == Default::default() {

--- a/moz-webgpu-cts/src/shared.rs
+++ b/moz-webgpu-cts/src/shared.rs
@@ -272,6 +272,16 @@ where
             })
         })
     }
+
+    pub(crate) fn iter_mut(
+        &mut self,
+    ) -> impl Iterator<Item = ((Platform, BuildProfile), &mut Expectation<Out>)> + '_ {
+        self.0.iter_mut().flat_map(|(platform, exps_by_bp)| {
+            exps_by_bp
+                .iter_mut()
+                .map(move |(build_profile, expectations)| ((platform, build_profile), expectations))
+        })
+    }
 }
 
 impl<Out> FullyExpandedExpectationPropertyValue<Out>

--- a/moz-webgpu-cts/src/shared.rs
+++ b/moz-webgpu-cts/src/shared.rs
@@ -147,6 +147,28 @@ where
     }
 }
 
+impl<Out> BitOr<EnumSet<Out>> for Expectation<Out>
+where
+    Out: EnumSetType,
+{
+    type Output = Self;
+
+    fn bitor(self, rhs: EnumSet<Out>) -> Self::Output {
+        let Self(lhs) = self;
+
+        Self(lhs | rhs)
+    }
+}
+
+impl<Out> BitOrAssign<EnumSet<Out>> for Expectation<Out>
+where
+    Out: EnumSetType,
+{
+    fn bitor_assign(&mut self, rhs: EnumSet<Out>) {
+        *self = *self | rhs;
+    }
+}
+
 impl<Out> BitOr<Out> for Expectation<Out>
 where
     Out: EnumSetType,

--- a/moz-webgpu-cts/src/shared.rs
+++ b/moz-webgpu-cts/src/shared.rs
@@ -85,6 +85,10 @@ where
         self.inner().iter()
     }
 
+    pub fn is_disjoint(&self, rep: EnumSet<Out>) -> bool {
+        self.inner().is_disjoint(rep)
+    }
+
     pub fn is_superset(&self, rep: &Expectation<Out>) -> bool
     where
         Out: std::fmt::Debug + Default + EnumSetType,


### PR DESCRIPTION
Currently, if one is running a WebGPU CTS test such that there's not
a deterministic place it will time out (like the tests with thousands of
tiny subtest cases that simply don't fit in the time budget `wptrunner`
gives them), it can take dozens to hundreds of runs to empirically
observe every single potential point of concretely timing out. This is
a problem when the goal is to converge expected outcomes in as few runs
as possible!

Resolve this as follows: If over the course of processing we encounter
any reconciled subtest outcomes that contain a `TIMEOUT` or `NOTRUN`
value, ensure _both_ `TIMEOUT` and `NOTRUN` are present in the
reconciled subtest outcomes.