### PR TITLE
feat(process_reports): allow spec. of zero reports, default `--preset` to `reset-contradictory`

### DIFF
--- a/moz-webgpu-cts/src/main.rs
+++ b/moz-webgpu-cts/src/main.rs
@@ -85,7 +85,7 @@ enum Subcommand {
         #[clap(long = "glob", value_name = "REPORT_GLOB")]
         report_globs: Vec<String>,
         /// The heuristic for resolving differences between current metadata and processed reports.
-        #[clap(long)]
+        #[clap(long, default_value = "reset-contradictory")]
         preset: ReportProcessingPreset,
     },
     /// Parse test metadata and re-emit it in normalized form.

--- a/moz-webgpu-cts/src/main.rs
+++ b/moz-webgpu-cts/src/main.rs
@@ -56,8 +56,8 @@ struct Cli {
 
 #[derive(Debug, Parser)]
 enum Subcommand {
-    /// Adjust test expectations in metadata using `wptreport.json` reports from CI runs covering
-    /// Firefox's implementation of WebGPU.
+    /// Adjust test expectations in metadata, optionally using `wptreport.json` reports from CI
+    /// runs covering Firefox's implementation of WebGPU.
     ///
     /// As Firefox's behavior changes, one generally expects CTS test outcomes to change. When you
     /// are testing your own changes in CI, you can use this subcommand to update expectations
@@ -84,8 +84,7 @@ enum Subcommand {
         /// forward slashes (`/`) are the only valid path separator for these globs.
         #[clap(long = "glob", value_name = "REPORT_GLOB")]
         report_globs: Vec<String>,
-        /// The heuristic for resolving differences between current metadata and processed reports
-        /// for this report processing run.
+        /// The heuristic for resolving differences between current metadata and processed reports.
         #[clap(long)]
         preset: ReportProcessingPreset,
     },
@@ -227,12 +226,7 @@ fn run(cli: Cli) -> ExitCode {
                 globs
             };
 
-            if report_paths.is_empty() && report_globs.is_empty() {
-                log::error!("no report paths specified, bailing");
-                return ExitCode::FAILURE;
-            }
-
-            let exec_report_paths = {
+            let report_paths_from_glob = {
                 let mut found_glob_walk_err = false;
                 let files = report_globs
                     .iter()
@@ -258,7 +252,6 @@ fn run(cli: Cli) -> ExitCode {
                             })
                             .collect::<Vec<_>>() // OPT: Can we get rid of this somehow?
                     })
-                    .chain(report_paths)
                     .collect::<Vec<_>>();
 
                 if found_glob_walk_err {
@@ -272,10 +265,26 @@ fn run(cli: Cli) -> ExitCode {
                 files
             };
 
-            if exec_report_paths.is_empty() {
-                log::error!("no WPT report files found, bailing");
-                return ExitCode::FAILURE;
+            if report_paths_from_glob.is_empty() && !report_globs.is_empty() {
+                if report_paths.is_empty() {
+                    log::error!(concat!(
+                        "reports were specified exclusively via glob search, ",
+                        "but none were found; bailing"
+                    ));
+                    return ExitCode::FAILURE;
+                } else {
+                    log::warn!(concat!(
+                        "report were specified via path and glob search, ",
+                        "but none were found via glob; ",
+                        "continuing with report paths"
+                    ))
+                }
             }
+
+            let exec_report_paths = report_paths
+                .into_iter()
+                .chain(report_paths_from_glob)
+                .collect::<Vec<_>>();
 
             log::trace!("working with the following WPT report files: {exec_report_paths:#?}");
             log::info!("working with {} WPT report files", exec_report_paths.len());
@@ -418,6 +427,8 @@ fn run(cli: Cli) -> ExitCode {
             }
 
             log::info!("gathering reported test outcomes for reconciliation with metadata…");
+
+            let using_reports = !exec_report_paths.is_empty();
 
             let (exec_reports_sender, exec_reports_receiver) = channel();
             exec_report_paths
@@ -663,7 +674,7 @@ fn run(cli: Cli) -> ExitCode {
                         log::info!("new test entry: {test_path:?}")
                     }
 
-                    if test_entry.reported.is_empty() {
+                    if test_entry.reported.is_empty() && using_reports {
                         let test_path = &test_path;
                         let msg = lazy_format!("no entries found in reports for {:?}", test_path);
                         match preset {


### PR DESCRIPTION
Previously, making these optional didn't make sense, as we didn't have any post-processing of metadata to do. Now that we _do_ have post-processing, it seems wise to make these optional, so users can call `process-reports` and get the post-processing without actually having to.

"But Erich!" you might say. "Don't we already expose the current post-processing via `fmt`?" And you'd be right! However, Mozilla is also considering a command that updating the `backlog` status _and_ be included in `fmt`, which would technically be separate from the intended purpose of `process-reports`, which is to update the `expected` field.

☝🏻Speaking of which, we should probably rename these commands to reflect their intent…🤔