### PR TITLE
Rework `TestScope` model to meet Servo's needs

### DIFF
--- a/moz-webgpu-cts/src/shared.rs
+++ b/moz-webgpu-cts/src/shared.rs
@@ -662,18 +662,22 @@ impl Display for MetadataTestPathError<'_> {
     }
 }
 
+/// A browser supported by [super::main], used for [`TestPath`]s.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, ValueEnum)]
 pub(crate) enum Browser {
     Firefox,
     Servo,
 }
 
+/// Symbolically represents a file root from which tests and metadata are based. Scopes are based
+/// on a specific [`Browser`].
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub(crate) enum TestScope {
     Firefox(FirefoxTestScope),
     Servo(ServoTestScope),
 }
 
+/// Subset of [`TestScope`] for [`Browser::Firefox`].
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub(crate) enum FirefoxTestScope {
     /// A public test available at some point in the history of [WPT upstream]. Note that while
@@ -691,8 +695,10 @@ impl From<FirefoxTestScope> for TestScope {
     }
 }
 
+/// Subset of [`TestScope`] for [`Browser::Servo`].
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub(crate) enum ServoTestScope {
+    /// A WebGPU CTS test vendored into Servo's source tree.
     WebGpu,
 }
 

--- a/moz-webgpu-cts/src/shared.rs
+++ b/moz-webgpu-cts/src/shared.rs
@@ -537,7 +537,7 @@ impl<'a> TestPath<'a> {
 
         Ok(Self {
             scope,
-            path: Utf8Path::new(path).into(),
+            path: path.into(),
             variant: variant.map(Into::into),
         })
     }

--- a/moz-webgpu-cts/src/shared.rs
+++ b/moz-webgpu-cts/src/shared.rs
@@ -435,12 +435,12 @@ pub(crate) struct TestPath<'a> {
     pub variant: Option<Cow<'a, str>>,
 }
 
-const SCOPE_DIR_FX_PRIVATE_STR: &str = "testing/web-platform/mozilla";
-const SCOPE_DIR_FX_PRIVATE_COMPONENTS: &[&str] = &["testing", "web-platform", "mozilla"];
-const SCOPE_DIR_FX_PUBLIC_STR: &str = "testing/web-platform";
-const SCOPE_DIR_FX_PUBLIC_COMPONENTS: &[&str] = &["testing", "web-platform"];
-const SCOPE_DIR_SERVO_PUBLIC_STR: &str = "tests/wpt/webgpu";
-const SCOPE_DIR_SERVO_PUBLIC_COMPONENTS: &[&str] = &["tests", "wpt", "webgpu"];
+const SCOPE_DIR_FX_MOZILLA_STR: &str = "testing/web-platform/mozilla";
+const SCOPE_DIR_FX_MOZILLA_COMPONENTS: &[&str] = &["testing", "web-platform", "mozilla"];
+const SCOPE_DIR_FX_UPSTREAM_STR: &str = "testing/web-platform";
+const SCOPE_DIR_FX_UPSTREAM_COMPONENTS: &[&str] = &["testing", "web-platform"];
+const SCOPE_DIR_SERVO_WEBGPU_STR: &str = "tests/wpt/webgpu";
+const SCOPE_DIR_SERVO_WEBGPU_COMPONENTS: &[&str] = &["tests", "wpt", "webgpu"];
 
 impl<'a> TestPath<'a> {
     pub fn from_execution_report(
@@ -511,8 +511,8 @@ impl<'a> TestPath<'a> {
         );
 
         let (private_path, public_path) = match browser {
-            Browser::Firefox => (SCOPE_DIR_FX_PRIVATE_STR, SCOPE_DIR_FX_PUBLIC_STR),
-            Browser::Servo => (SCOPE_DIR_FX_PRIVATE_STR, SCOPE_DIR_SERVO_PUBLIC_STR),
+            Browser::Firefox => (SCOPE_DIR_FX_MOZILLA_STR, SCOPE_DIR_FX_UPSTREAM_STR),
+            Browser::Servo => (SCOPE_DIR_FX_MOZILLA_STR, SCOPE_DIR_SERVO_WEBGPU_STR),
         };
         let (visibility, path) = if let Ok(path) = rel_meta_file_path.strip_prefix(private_path) {
             (TestVisibility::Private, path)
@@ -621,9 +621,9 @@ impl<'a> TestPath<'a> {
             visibility,
         } = scope;
         let scope_dir = match (browser, visibility) {
-            (Browser::Firefox, TestVisibility::Public) => SCOPE_DIR_FX_PUBLIC_COMPONENTS,
-            (Browser::Firefox, TestVisibility::Private) => SCOPE_DIR_FX_PRIVATE_COMPONENTS,
-            (Browser::Servo, TestVisibility::Public) => SCOPE_DIR_SERVO_PUBLIC_COMPONENTS,
+            (Browser::Firefox, TestVisibility::Public) => SCOPE_DIR_FX_UPSTREAM_COMPONENTS,
+            (Browser::Firefox, TestVisibility::Private) => SCOPE_DIR_FX_MOZILLA_COMPONENTS,
+            (Browser::Servo, TestVisibility::Public) => SCOPE_DIR_SERVO_WEBGPU_COMPONENTS,
             (Browser::Servo, TestVisibility::Private) => todo!(),
         }
         .iter()

--- a/moz-webgpu-cts/src/shared.rs
+++ b/moz-webgpu-cts/src/shared.rs
@@ -449,16 +449,16 @@ impl<'a> TestPath<'a> {
     ) -> Result<Self, ExecutionReportPathError<'a>> {
         let err = || ExecutionReportPathError { test_url_path };
 
-        let try_strip_with = |prefix, visibility| {
+        let strip_prefix = |prefix, visibility| {
             test_url_path
                 .strip_prefix(prefix)
                 .map(|stripped| (visibility, stripped))
         };
         let vis_and_path = match browser {
-            Browser::Firefox => try_strip_with("/_mozilla/", TestVisibility::Private),
-            Browser::Servo => try_strip_with("/_webgpu/", TestVisibility::Public),
+            Browser::Firefox => strip_prefix("/_mozilla/", TestVisibility::Private),
+            Browser::Servo => strip_prefix("/_webgpu/", TestVisibility::Public),
         }
-        .or_else(|| try_strip_with("/", TestVisibility::Public));
+        .or_else(|| strip_prefix("/", TestVisibility::Public));
         let Some((visibility, path)) = vis_and_path else {
             return Err(err());
         };

--- a/moz-webgpu-cts/src/shared.rs
+++ b/moz-webgpu-cts/src/shared.rs
@@ -669,6 +669,12 @@ pub(crate) enum Browser {
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(crate) enum TestScope {
+    Firefox(FirefoxTestScope),
+    Servo(ServoTestScope),
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub(crate) enum FirefoxTestScope {
     /// A public test available at some point in the history of [WPT upstream]. Note that while
     /// a test may be public, metadata associated with it is in a private location.
@@ -694,13 +700,6 @@ impl From<ServoTestScope> for TestScope {
     fn from(value: ServoTestScope) -> Self {
         Self::Servo(value)
     }
-}
-
-/// Symbolically represents a file root from which tests and metadata are based.
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub(crate) enum TestScope {
-    Firefox(FirefoxTestScope),
-    Servo(ServoTestScope),
 }
 
 #[test]

--- a/moz-webgpu-cts/src/shared.rs
+++ b/moz-webgpu-cts/src/shared.rs
@@ -454,14 +454,12 @@ impl<'a> TestPath<'a> {
                 .strip_prefix(prefix)
                 .map(|stripped| (visibility, stripped))
         };
-        let vis_and_path = match browser {
+        let (visibility, path) = match browser {
             Browser::Firefox => strip_prefix("/_mozilla/", TestVisibility::Private),
             Browser::Servo => strip_prefix("/_webgpu/", TestVisibility::Public),
         }
-        .or_else(|| strip_prefix("/", TestVisibility::Public));
-        let Some((visibility, path)) = vis_and_path else {
-            return Err(err());
-        };
+        .or_else(|| strip_prefix("/", TestVisibility::Public))
+        .ok_or_else(err)?;
         let scope = TestScope {
             browser,
             visibility,

--- a/moz-webgpu-cts/src/shared.rs
+++ b/moz-webgpu-cts/src/shared.rs
@@ -594,6 +594,7 @@ impl<'a> TestPath<'a> {
     }
 }
 
+/// An error encountered during [`TestPath::from_execution_report`].
 #[derive(Debug)]
 pub struct ExecutionReportPathError<'a> {
     test_url_path: &'a str,
@@ -613,6 +614,7 @@ impl Display for ExecutionReportPathError<'_> {
     }
 }
 
+/// An error encountered during [`TestPath::from_metadata_test`].
 #[derive(Debug)]
 pub struct MetadataTestPathError<'a> {
     rel_meta_file_path: &'a Path,


### PR DESCRIPTION
In #92, I had suggested a new representation for `TestScope` where `Browser` and `TestVisibility` were two dimensions on which other products could integrate with `moz-webgpu-cts`. However, that model is wrong; Servo only really has _one_ set of paths and runner URLs that it cares about, currently. One can observe this with the `todo!()`s that I merged in that PR. 😅 So, I'm fixing my mistake!

Throw away `TestVisibility` and make `TestScope` mirror `Browser` variants with additional, independent structure per-browser. Concretely, make `TestScope` use either a `FirefoxTestScope` or a `ServoTestScope`, the latter of which only has a `WebGpu` variant (for now).