### PR TITLE
Add `dump-json` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,6 +1047,7 @@ dependencies = [
  "format",
  "indexmap",
  "insta",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,6 +303,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
 dependencies = [
  "enum-map-derive",
+ "serde",
 ]
 
 [[package]]
@@ -323,6 +324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "226c0da7462c13fb57e5cc9e0dc8f0635e7d27f276a3a7fd30054647f669007d"
 dependencies = [
  "enumset_derive",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,9 @@ name = "camino"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ format = "0.2.4"
 indexmap = "2.0.0"
 insta = "1.38.0"
 log = "0.4.20"
+serde = { version = "1.0.188", features = ["derive"] }
 thiserror = "1.0.49"
 
 # The profile that 'cargo dist' will build with

--- a/moz-webgpu-cts/Cargo.toml
+++ b/moz-webgpu-cts/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 dist = true
 
 [dependencies]
-camino = "1.1.6"
+camino = { version = "1.1.6", features = ["serde1"] }
 clap = { version = "4.4.2", features = ["derive"] }
 env_logger = "0.10.0"
 enumset = { version = "1.1.3", features = ["serde"] }

--- a/moz-webgpu-cts/Cargo.toml
+++ b/moz-webgpu-cts/Cargo.toml
@@ -14,7 +14,7 @@ dist = true
 camino = "1.1.6"
 clap = { version = "4.4.2", features = ["derive"] }
 env_logger = "0.10.0"
-enumset = "1.1.3"
+enumset = { version = "1.1.3", features = ["serde"] }
 format = { workspace = true }
 indexmap = { workspace = true }
 itertools = "0.11.0"
@@ -30,8 +30,8 @@ serde_json = "1.0.107"
 strum = { version = "0.25.0", features = ["derive"] }
 thiserror = { workspace = true }
 wax = { version = "0.6.0", features = ["miette"], git = "https://github.com/ErichDonGubler/wax", branch = "static-miette-diags"}
-whippit = { version = "0.6.0", path = "../whippit", default-features = false }
-enum-map = "2.7.3"
+whippit = { version = "0.6.0", path = "../whippit", default-features = false, features = ["serde1"] }
+enum-map = { version = "2.7.3", features = ["serde"] }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/moz-webgpu-cts/Cargo.toml
+++ b/moz-webgpu-cts/Cargo.toml
@@ -25,7 +25,7 @@ miette = { version = "5.10.0", features = ["fancy"] }
 natord = "1.0.9"
 path-dsl = "0.6.1"
 rayon = "1.8.0"
-serde = { version = "1.0.188", features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0.107"
 strum = { version = "0.25.0", features = ["derive"] }
 thiserror = { workspace = true }

--- a/moz-webgpu-cts/src/metadata.rs
+++ b/moz-webgpu-cts/src/metadata.rs
@@ -8,7 +8,7 @@ use enum_map::Enum;
 use enumset::EnumSetType;
 use format::lazy_format;
 use joinery::JoinableIterator;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use strum::EnumIter;
 use whippit::{
     metadata::{
@@ -34,7 +34,7 @@ use crate::shared::{ExpandedPropertyValue, Expected, MaybeCollapsed, NormalizedP
 #[cfg(test)]
 use insta::assert_debug_snapshot;
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Serialize)]
 pub struct File {
     pub properties: FileProps,
     pub tests: BTreeMap<SectionHeader, Test>,
@@ -56,7 +56,7 @@ impl<'a> metadata::File<'a> for File {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Serialize)]
 pub struct FileProps {
     pub is_disabled: Option<PropertyValue<Expr<Value<'static>>, String>>,
     #[allow(clippy::type_complexity)]
@@ -562,7 +562,7 @@ fn format_file_properties(props: &FileProps) -> impl Display + '_ {
     })
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
 pub enum ImplementationStatus {
     /// Indicates that functionality governing test(s) is implemented or currently being
     /// implemented, and generally expected to conform to tests.
@@ -631,7 +631,7 @@ impl<'a> metadata::Tests<'a> for Tests {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Serialize)]
 pub struct Test {
     pub properties: TestProps<TestOutcome>,
     pub subtests: BTreeMap<SectionHeader, Subtest>,
@@ -678,7 +678,7 @@ impl<'a> metadata::Subtests<'a> for Subtests {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Serialize)]
 pub struct Subtest {
     pub properties: TestProps<SubtestOutcome>,
 }
@@ -844,20 +844,20 @@ where
     })
 }
 
-#[derive(Clone, Copy, Debug, Enum, EnumIter, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Enum, EnumIter, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum Platform {
     Windows,
     Linux,
     MacOs,
 }
 
-#[derive(Clone, Copy, Debug, Enum, EnumIter, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Enum, EnumIter, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum BuildProfile {
     Debug,
     Optimized,
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
 pub struct TestProps<Out>
 where
     Out: EnumSetType,
@@ -1179,7 +1179,9 @@ pub(crate) const CRASH: &str = "CRASH";
 pub(crate) const OK: &str = "OK";
 pub(crate) const ERROR: &str = "ERROR";
 
-#[derive(Debug, Deserialize, EnumSetType, Hash)]
+#[derive(Debug, Deserialize, EnumSetType, Hash, Serialize)]
+#[enumset(serialize_repr = "list")]
+#[enumset(serialize_deny_unknown)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum TestOutcome {
     Ok,
@@ -1234,7 +1236,9 @@ impl<'a> Properties<'a> for TestProps<TestOutcome> {
     }
 }
 
-#[derive(Debug, Deserialize, EnumSetType, Hash)]
+#[derive(Debug, Deserialize, EnumSetType, Hash, Serialize)]
+#[enumset(serialize_repr = "list")]
+#[enumset(serialize_deny_unknown)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum SubtestOutcome {
     Pass,

--- a/moz-webgpu-cts/src/shared.rs
+++ b/moz-webgpu-cts/src/shared.rs
@@ -15,6 +15,7 @@ use enumset::{EnumSet, EnumSetType};
 use format::lazy_format;
 use itertools::Itertools;
 use joinery::JoinableIterator;
+use serde::Serialize;
 
 use crate::metadata::{BuildProfile, Platform};
 
@@ -25,7 +26,7 @@ use crate::metadata::{BuildProfile, Platform};
 ///
 /// [`Test`]: crate::metadata::Test
 /// [`Subtest`]: crate::metadata::Subtest
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Serialize)]
 pub struct Expected<Out>(EnumSet<Out>)
 where
     Out: EnumSetType;
@@ -231,7 +232,7 @@ where
 
 /// A completely flat representation of [`NormalizedPropertyValue`] suitable for byte
 /// representation in memory.
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Serialize)]
 pub struct ExpandedPropertyValue<T>(ExpandedPropertyValueData<T>);
 
 impl<T> Index<(Platform, BuildProfile)> for ExpandedPropertyValue<T> {

--- a/whippit/Cargo.toml
+++ b/whippit/Cargo.toml
@@ -10,11 +10,13 @@ publish = false
 [features]
 default = ["unstructured-properties"]
 unstructured-properties = ["dep:indexmap"]
+serde1 = ["dep:serde"]
 
 [dependencies]
 chumsky = { version = "1.0.0-alpha.6", features = ["label", "pratt"] }
 format = { workspace = true }
 indexmap = { workspace = true, optional = true }
+serde = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/whippit/src/metadata.rs
+++ b/whippit/src/metadata.rs
@@ -1140,6 +1140,7 @@ fn test_indent() {
 }
 
 #[derive(Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde1", derive(serde::Deserialize, serde::Serialize))]
 pub struct SectionHeader(pub String);
 
 impl Debug for SectionHeader {

--- a/whippit/src/metadata/properties.rs
+++ b/whippit/src/metadata/properties.rs
@@ -29,6 +29,7 @@ use crate::metadata::{indent, ParseError};
 /// [`Test`]: crate::metadata::Test
 /// [`Subtest`]: crate::metadata::Subtest
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde1", derive(serde::Deserialize, serde::Serialize))]
 pub enum PropertyValue<C, V> {
     /// A property value that is only ever a specific value.
     Unconditional(V),

--- a/whippit/src/metadata/properties/conditional.rs
+++ b/whippit/src/metadata/properties/conditional.rs
@@ -265,6 +265,7 @@ fn test_conditional_fallback() {
 
 /// Values placed into a [`super::PropertyValue::Conditional`].
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde1", derive(serde::Deserialize, serde::Serialize))]
 pub struct ConditionalValue<C, V> {
     /// Conditional clauses and their resulting values if evaluated to true.
     pub conditions: Vec<(C, V)>,

--- a/whippit/src/metadata/properties/conditional/expr.rs
+++ b/whippit/src/metadata/properties/conditional/expr.rs
@@ -15,6 +15,7 @@ use crate::metadata::ParseError;
 
 /// Values that can be placed into [`Value::Literal`].
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde1", derive(serde::Deserialize, serde::Serialize))]
 pub enum Literal<'a> {
     /// At time of writing, no escaping is used for string values in this implementation.
     String(Cow<'a, str>),
@@ -42,6 +43,7 @@ impl<'a> Literal<'a> {
 /// Variable and literal values supported by [WPT metadata
 /// properties](crate::metadata::properties). Usually the terminal of a [`Expr`] expression.
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde1", derive(serde::Deserialize, serde::Serialize))]
 pub enum Value<'a> {
     Variable(Cow<'a, str>),
     Literal(Literal<'a>),
@@ -74,6 +76,7 @@ impl<'a> Value<'a> {
 /// [`Properties`]: crate::metadata::properties::Properties
 /// [`Properties::property_parser`]: crate::metadata::properties::Properties::property_parser
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde1", derive(serde::Deserialize, serde::Serialize))]
 pub enum Expr<V> {
     Value(V),
     And(Box<Expr<V>>, Box<Expr<V>>),


### PR DESCRIPTION
Mozilla is interested in using HTML and JS to create dashboards for its progress in writing a conformant implementation of WebGPU. If we can convert WPT metadata to JSON, we would have an easily accessible way of creating web pages that implement these dashboards!