### PR TITLE
Support `*.worker.js` metadata and reports

### DIFF
--- a/moz-webgpu-cts/src/main.rs
+++ b/moz-webgpu-cts/src/main.rs
@@ -290,11 +290,12 @@ fn run(cli: Cli) -> ExitCode {
 
             fn cts_path(test_entry_path: &TestEntryPath<'_>) -> Option<String> {
                 test_entry_path
+                    .test_entry
                     .variant
                     .as_ref()
                     .filter(|v| v.starts_with("?q=webgpu:"))
                     .map(|v| v.strip_prefix("?q=").unwrap().to_owned())
-                    .filter(|_q| test_entry_path.path.ends_with("cts.https.html"))
+                    .filter(|_q| test_entry_path.spec_path.path.ends_with("cts.https.html"))
             }
 
             let mut file_props_by_file = IndexMap::<Utf8PathBuf, FileProps>::default();

--- a/moz-webgpu-cts/src/wpt/path.rs
+++ b/moz-webgpu-cts/src/wpt/path.rs
@@ -78,9 +78,7 @@ impl SpecType {
 
     pub fn from_base_name(base_name: &str) -> Option<(Self, &str)> {
         Self::iter().find_map(|variant| {
-            base_name
-                .strip_suffix(variant.file_extension())
-                .map(|some| (variant, some))
+            strip_suffix_with_value(base_name, variant.file_extension(), variant)
         })
     }
 
@@ -430,6 +428,10 @@ impl From<ServoRootDir> for RootDir {
     fn from(value: ServoRootDir) -> Self {
         Self::Servo(value)
     }
+}
+
+fn strip_suffix_with_value<'a, T>(s: &'a str, suffix: &str, t: T) -> Option<(T, &'a str)> {
+    s.strip_suffix(suffix).map(|some| (t, some))
 }
 
 #[test]


### PR DESCRIPTION
Resolves https://github.com/ErichDonGubler/moz-webgpu-cts/issues/122.