### PR TITLE
 fix(update_expected)!: remove unreported subtests a la tests 

### DIFF
--- a/moz-webgpu-cts/src/main.rs
+++ b/moz-webgpu-cts/src/main.rs
@@ -728,6 +728,24 @@ fn run(cli: Cli) -> ExitCode {
                                 reported: subtest_reported,
                             } = subtest;
 
+                            if subtest_reported.is_empty() && using_reports {
+                                let test_entry_path = &test_entry_path;
+                                let subtest_name = &subtest_name;
+                                let msg = lazy_format!(
+                                    "no subtest entries found in reports for {:?}, subtest {:?}",
+                                    test_entry_path,
+                                    subtest_name,
+                                );
+                                match preset {
+                                    ReportProcessingPreset::Merge => log::warn!("{msg}"),
+                                    ReportProcessingPreset::ResetAll
+                                    | ReportProcessingPreset::ResetContradictory => {
+                                        log::warn!("removing metadata after {msg}");
+                                        return None;
+                                    }
+                                }
+                            }
+
                             let mut subtest_properties = subtest_properties.unwrap_or_default();
                             reconcile(
                                 properties.implementation_status.as_ref(),


### PR DESCRIPTION
This is something I forgot to do while implementing `process-reports`/`update-expected` originally! Oops. 😳 Mozilla had accumulated ~55k lines of metadata that it didn't need because this hadn't been implemented yet.

I've observed that `wptrunner` may not report subtests in `wptreport.json` artifacts in some cases while running CTS. This may cause some noise in folks' existing Try runs (i.e., deletions), and we might need to make this an option later, if the problems aren't easy to resolve.