### PR TITLE
refactor(update_expected): hoist logic for `expected` filtering to callers of `process_reports`

### DIFF
--- a/moz-webgpu-cts/src/process_reports.rs
+++ b/moz-webgpu-cts/src/process_reports.rs
@@ -23,7 +23,7 @@ use crate::{
     taint_subtest_timeouts_by_suspicion,
     wpt::{
         metadata::{
-            properties::{ExpandedPropertyValue, Expected},
+            properties::{ExpandedPropertyValue, Expected, NonNormalizedPropertyValue},
             BuildProfile, File, FileProps, ImplementationStatus, Platform, Subtest, SubtestOutcome,
             Test, TestOutcome, TestProps,
         },
@@ -38,7 +38,7 @@ where
     Out: EnumSetType,
 {
     pub meta_props: Option<TestProps<Out>>,
-    pub reported: BTreeMap<Platform, BTreeMap<BuildProfile, Expected<Out>>>,
+    pub reported: NonNormalizedPropertyValue<Expected<Out>>,
 }
 
 #[derive(Debug, Default)]
@@ -83,7 +83,7 @@ fn cts_path(test_entry_path: &TestEntryPath<'_>) -> Option<String> {
 }
 
 fn accumulate<Out>(
-    recorded: &mut BTreeMap<Platform, BTreeMap<BuildProfile, Expected<Out>>>,
+    recorded: &mut NonNormalizedPropertyValue<Expected<Out>>,
     platform: Platform,
     build_profile: BuildProfile,
     reported_outcome: Out,
@@ -108,7 +108,7 @@ fn accumulate<Out>(
 fn reconcile<Out>(
     parent_implementation_status: Option<&ExpandedPropertyValue<ImplementationStatus>>,
     meta_props: &mut TestProps<Out>,
-    reported: BTreeMap<Platform, BTreeMap<BuildProfile, Expected<Out>>>,
+    reported: NonNormalizedPropertyValue<Expected<Out>>,
     preset: ReportProcessingPreset,
     implementation_status_filter: EnumSet<ImplementationStatus>,
 ) where

--- a/moz-webgpu-cts/src/process_reports/should_update_expected.rs
+++ b/moz-webgpu-cts/src/process_reports/should_update_expected.rs
@@ -1,0 +1,62 @@
+use std::fmt::Debug;
+
+use enumset::EnumSet;
+
+use crate::wpt::metadata::{
+    properties::{Expected, NonNormalizedPropertyValue},
+    BuildProfile, ImplementationStatus, Platform, SubtestOutcome, TestOutcome, TestProps,
+};
+
+pub(crate) trait ShouldUpdateExpected: Debug {
+    fn test(
+        &mut self,
+        meta_props: &TestProps<TestOutcome>,
+        reported: &NonNormalizedPropertyValue<Expected<TestOutcome>>,
+        key: (Platform, BuildProfile),
+    ) -> bool;
+    fn subtest(
+        &mut self,
+        meta_props: &TestProps<SubtestOutcome>,
+        reported: &NonNormalizedPropertyValue<Expected<SubtestOutcome>>,
+        parent_meta_props: &TestProps<TestOutcome>,
+        key: (Platform, BuildProfile),
+    ) -> bool;
+}
+
+#[derive(Debug)]
+pub(crate) struct ImplementationStatusFilter {
+    pub allowed: EnumSet<ImplementationStatus>,
+}
+
+impl ImplementationStatusFilter {
+    fn is_allowed(&self, implementation_status: ImplementationStatus) -> bool {
+        let Self { allowed } = self;
+        allowed.contains(implementation_status)
+    }
+}
+
+impl ShouldUpdateExpected for ImplementationStatusFilter {
+    fn test(
+        &mut self,
+        meta_props: &TestProps<TestOutcome>,
+        _reported: &NonNormalizedPropertyValue<Expected<TestOutcome>>,
+        key: (Platform, BuildProfile),
+    ) -> bool {
+        let status = meta_props.implementation_status.unwrap_or_default()[key];
+        self.is_allowed(status)
+    }
+
+    fn subtest(
+        &mut self,
+        meta_props: &TestProps<SubtestOutcome>,
+        _reported: &NonNormalizedPropertyValue<Expected<SubtestOutcome>>,
+        parent_meta_props: &TestProps<TestOutcome>,
+        key: (Platform, BuildProfile),
+    ) -> bool {
+        let status = meta_props
+            .implementation_status
+            .or(parent_meta_props.implementation_status)
+            .unwrap_or_default()[key];
+        self.is_allowed(status)
+    }
+}

--- a/moz-webgpu-cts/src/wpt/metadata/properties.rs
+++ b/moz-webgpu-cts/src/wpt/metadata/properties.rs
@@ -400,8 +400,10 @@ where
     }
 }
 
-/// Data from a [`NormalizedPropertyValue`].
+/// Data from a [`NormalizedPropertyValue`]. A normalized form of [`NonNormalizedPropertyValue`].
 pub type NormalizedPropertyValueData<T> = Normalized<Platform, Normalized<BuildProfile, T>>;
 
 /// A value that is either `V` or a set of `V`s branched on by `K`.
 pub type Normalized<K, V> = MaybeCollapsed<V, BTreeMap<K, V>>;
+
+pub type NonNormalizedPropertyValue<T> = BTreeMap<Platform, BTreeMap<BuildProfile, T>>;


### PR DESCRIPTION
In preparation for #127.